### PR TITLE
Migrate to OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ In the spirit of FAAFO (fuck around and find out), I created this small CLI app 
 - [x] ~Function calling to actually apply the changes.~ I used structured output instead to make it easier to parse the output.
 - [x] Make it run on my M1 Pro in a reasonable amount of time. This would make it a viable tool for most developers. My M4 Pro is a cheat code.
 - [ ] Handle yaml files as well.
+- [ ] Test this app on a large OpenAPI spec.
 
 ## Nice to have enhancements
 - [ ] Split between fixing syntax and improving spec documentation.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # FAAFO Go cli
 In the spirit of FAAFO (fuck around and find out), I created this small CLI app as part of a hacking hour with [tamirarnesty](https://github.com/tamirarnesty). The POC we were trying to build here is validating an OpenAPI json document.
 
+> ⚠️ I have resorted to using OpenAI's ChatGPT-4o-mini model as I could not get small models that can run on my MacBook to produce the desired output.
+
 ## Planned improvements
-- [ ] Function calling to actually apply the changes.
+- [x] ~Function calling to actually apply the changes.~ I used structured output instead to make it easier to parse the output.
+- [x] Make it run on my M1 Pro in a reasonable amount of time. This would make it a viable tool for most developers. My M4 Pro is a cheat code.
+- [ ] Handle yaml files as well.
+
+## Nice to have enhancements
 - [ ] Split between fixing syntax and improving spec documentation.
 - [ ] Implement other tools like redocly to chunk larger schema files and run the clean up as a pipeline.
-- [ ] Learn benchmarking and improve the app->response performance.
-- [x] Make it run on my M1 Pro in a reasonable amount of time. This would make it a viable tool for most developers. My M4 Pro is a cheat code.
+- [ ] Learn how to fine-tune a small model to improve the accuracy of the output and use the evals framework to evaluate the LLM.
+
 
 ## How to run the app
 1. Install Ollama with `brew install ollama && ollama pull `
@@ -22,7 +28,7 @@ delta files/sample-api.json files/output-fix.json
 ## Bill of Materials
 1. Official OpenAI go client
 2. Ollama official docker image
-3. llama3.2 3b model
+3. OpenAI ChatGPT-4o-mini model
 
 
 # Learnings

--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,14 @@ go 1.23.4
 
 require (
 	github.com/invopop/jsonschema v0.13.0
-	github.com/openai/openai-go v0.1.0-alpha.55
+	github.com/openai/openai-go v0.1.0-alpha.59
 	github.com/sirupsen/logrus v1.9.3
 )
 
 require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
-	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,11 +7,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
-github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
-github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/openai/openai-go v0.1.0-alpha.55 h1:J1LDFRkp+dlHE0dEcDd9eN606co1xb+PQPKM/QznTwk=
-github.com/openai/openai-go v0.1.0-alpha.55/go.mod h1:3SdE6BffOX9HPEQv8IL/fi3LYZ5TUpRYaqGQZbyk11A=
+github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
+github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
+github.com/openai/openai-go v0.1.0-alpha.59 h1:T3IYwKSCezfIlL9Oi+CGvU03fq0RoH33775S78Ti48Y=
+github.com/openai/openai-go v0.1.0-alpha.59/go.mod h1:3SdE6BffOX9HPEQv8IL/fi3LYZ5TUpRYaqGQZbyk11A=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/invopop/jsonschema"
 	"github.com/openai/openai-go"
-	"github.com/openai/openai-go/option"
 )
 
 const (
@@ -43,9 +42,7 @@ func main() {
 		log.Fatal("failed to read system prompt file: ", error)
 	}
 
-	client := openai.NewClient(
-		option.WithAPIKey(os.Getenv("OPENAI_API_KEY")),
-	)
+	client := openai.NewClient()
 
 	response, err := chat(ctx, client, openai.ChatModelGPT4oMini, systemPrompt, jsonFile)
 	if err != nil {


### PR DESCRIPTION
This pull request includes several changes to the `README.md`, `go.mod`, and `main.go` files to update dependencies and improve the functionality of the FAAFO Go CLI application. The most important changes include updating the OpenAI model used, modifying the `README.md` to reflect these changes, and updating the Go module dependencies.

Updates to OpenAI model and dependencies:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R4-R16): Updated to indicate the use of OpenAI's ChatGPT-4o-mini model and marked some planned improvements as completed. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R4-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R32)
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L7-R14): Updated the `openai-go` dependency to version `v0.1.0-alpha.59` and `easyjson` to version `v0.9.0`.

Code adjustments:

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L13-R23): Removed unused import `option` from `openai-go` and updated the client instantiation to use the default base URL. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L13-R23) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L48-R47)
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L48-R47): Changed the model parameter in the `chat` function call to use `openai.ChatModelGPT4oMini` and updated the `schemaParam.Name` to "validated_open_api_spec". [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L48-R47) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L74-R71)
